### PR TITLE
Return of optimization whores

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,9 +32,7 @@ pub fn build(b: *std.Build) void {
     exe.override_dest_dir = std.Build.InstallDir{
         .custom = "boot",
     };
-    exe.rdynamic = true;
     exe.addAssemblyFileSource(.{ .path = "src/arch/x86/start.s" });
-
 
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -5,14 +5,8 @@ SECTIONS {
 	.multiboot :
 	{
 		/* KEEP otherwise it gets garbage collected by linker */
-		WORD(.multiboot)
+		*(.multiboot)
 		. = ALIGN(2K);
-	}
-
-	.dynamic :
-	{
-		*(.dynamic .dynamic.*)
-		. = ALIGN(4K);
 	}
 
 	.text :

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,22 +3,22 @@ const FLAGS = @as(u32, (1 << 2));
 
 // Attempt to place the multiboot header at the beginning of the binary
 pub export var multiboot_header: multiboot.MultibootHeader linksection(".multiboot") = .{
-        .magic = MAGIC,
-        .flags = FLAGS,
-        .checksum = ~(MAGIC +% FLAGS) +% 1,
+    .magic = MAGIC,
+    .flags = FLAGS,
+    .checksum = ~(MAGIC +% FLAGS) +% 1,
 
-        .header_addr = 0,
-        .load_addr = 0,
-        .load_end_addr = 0,
-        .bss_end_addr = 0,
-        .entry_addr = 0,
+    .header_addr = 0,
+    .load_addr = 0,
+    .load_end_addr = 0,
+    .bss_end_addr = 0,
+    .entry_addr = 0,
 
-        // Video mode information, since flags[2] is set
-        .mode_type = 1,     // 1 = text mode
-        .width = 80,        // Width and height in character count
-        .height = 25,
-        .depth = 0
-        // Depth is always 0 in text mode
+    // Video mode information, since flags[2] is set
+    .mode_type = 1, // 1 = text mode
+    .width = 80, // Width and height in character count
+    .height = 25,
+    .depth = 0,
+    // Depth is always 0 in text mode
 };
 
 const vga = @import("vga.zig");
@@ -31,6 +31,8 @@ const stack_bytes_slice = stack_bytes[0..];
 
 // Main kernel entry
 export fn kmain(magic: u32, info: *const multiboot.MultibootInfo) void {
+    std.mem.doNotOptimizeAway(multiboot_header);
+
     // Set the stack pointer to the correct location
     _ = .{ .stack = stack_bytes_slice };
     std.debug.assert(magic == multiboot.MULTIBOOT_BOOTLOADER_MAGIC);


### PR DESCRIPTION
Truly a nerdy thing going on here. Removes the `rdynamic` flag from the executable in the build script, the `dynamic` section from the linker script, and ensures the multiboot header will exist in the output file at all times without majorly increasing the size of the image.